### PR TITLE
Fix Resource Owner Password Authentication Flow

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -11,7 +11,7 @@ Doorkeeper.configure do
   end
 
   resource_owner_from_credentials do |routes|
-    u = User.find_by(email: params[:username])
+    u = User.find_by(email: params[:username]) || User.find_by(username: params[:username])
     u if u && u.valid_password?(params[:password])
   end
 
@@ -100,3 +100,4 @@ Doorkeeper.configure do
   # set to true if you want this to be allowed
   # wildcard_redirect_uri false
 end
+Doorkeeper.configuration.token_grant_types << "password"


### PR DESCRIPTION
As per the documentation here:
<code>https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Resource-Owner-Password-Credentials-flow</code>
to make "password" type grant_flow work once should add
<code>Doorkeeper.configuration.token_grant_types << "password"</code>
after Doorkeeper.configure do block

I have also added a check against username field such that OAUTH can be used with both email and username fields.
